### PR TITLE
Fix default for DiscordNotificationWikiUrlEndingUserRight

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -105,7 +105,7 @@
 			"value": "index.php?title="
 		},
 		"DiscordNotificationWikiUrlEndingUserRights": {
-			"value": "Special%3AUserRights&user="
+			"value": "Special:UserRights/"
 		},
 		"DiscordNotificationWikiUrlEndingBlockList": {
 			"value": "Special:BlockList"


### PR DESCRIPTION
Update default for DiscordNotificationWikiUrlEndingUserRights to work with the latest and default configuration of Mediawiki, including the version used in all of Miraheze.

This specifically fixes the bug of Special:UserRights (groups link in discord embed) not working by default.